### PR TITLE
Renamed Stock struct and Fetch class. Moved struct Stock to its own file

### DIFF
--- a/TA Signals.xcodeproj/project.pbxproj
+++ b/TA Signals.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		680E0DA326AD3C6000D06D28 /* FetchStocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680E0DA226AD3C6000D06D28 /* FetchStocks.swift */; };
+		680E0DA326AD3C6000D06D28 /* StocksDataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680E0DA226AD3C6000D06D28 /* StocksDataFetcher.swift */; };
+		6851BA6A26AEE84A00E52C4B /* Stock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6851BA6926AEE84A00E52C4B /* Stock.swift */; };
 		6865F1542684448B00C098B1 /* TA_SignalsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6865F1532684448B00C098B1 /* TA_SignalsApp.swift */; };
 		6865F1562684448B00C098B1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6865F1552684448B00C098B1 /* ContentView.swift */; };
 		6865F1582684448D00C098B1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6865F1572684448D00C098B1 /* Assets.xcassets */; };
@@ -34,7 +35,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		680E0DA226AD3C6000D06D28 /* FetchStocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStocks.swift; sourceTree = "<group>"; };
+		680E0DA226AD3C6000D06D28 /* StocksDataFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StocksDataFetcher.swift; sourceTree = "<group>"; };
+		6851BA6926AEE84A00E52C4B /* Stock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stock.swift; sourceTree = "<group>"; };
 		6865F1502684448B00C098B1 /* TA Signals.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TA Signals.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6865F1532684448B00C098B1 /* TA_SignalsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TA_SignalsApp.swift; sourceTree = "<group>"; };
 		6865F1552684448B00C098B1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -102,7 +104,8 @@
 				6865F1572684448D00C098B1 /* Assets.xcassets */,
 				6865F15C2684448D00C098B1 /* Info.plist */,
 				6865F1592684448D00C098B1 /* Preview Content */,
-				680E0DA226AD3C6000D06D28 /* FetchStocks.swift */,
+				680E0DA226AD3C6000D06D28 /* StocksDataFetcher.swift */,
+				6851BA6926AEE84A00E52C4B /* Stock.swift */,
 			);
 			path = "TA Signals";
 			sourceTree = "<group>";
@@ -264,7 +267,8 @@
 			files = (
 				6865F1562684448B00C098B1 /* ContentView.swift in Sources */,
 				6865F1542684448B00C098B1 /* TA_SignalsApp.swift in Sources */,
-				680E0DA326AD3C6000D06D28 /* FetchStocks.swift in Sources */,
+				6851BA6A26AEE84A00E52C4B /* Stock.swift in Sources */,
+				680E0DA326AD3C6000D06D28 /* StocksDataFetcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TA Signals/ContentView.swift
+++ b/TA Signals/ContentView.swift
@@ -7,23 +7,9 @@
 
 import SwiftUI
 
-/*
- * The Stocks struct will hold the JSON data output. Conforms to Codable and Identifiable protocols in order to work properly with JSON objects
- */
-struct Stocks: Codable, Identifiable {
-
-    var id: Int
-    var ticker : String
-    // TODO: https://github.com/iamgabrielma/TA-Signals/issues/4
-    var rsi: String
-    var ema100: String
-    var ema200: String
-    var signal: String
-}
-
 struct ContentView: View {
     // 1. The fetch property will observe the FetchToDo class for changes
-    @State var fetchedObject = FetchStocks()
+    @State var fetchedObject = StocksDataFetcher()
     @State var showFetchDetails : Bool = false
     @State var isMarketOpen : Bool = true
     let now = Date()

--- a/TA Signals/Stock.swift
+++ b/TA Signals/Stock.swift
@@ -1,0 +1,21 @@
+//
+//  Stock.swift
+//  TA Signals
+//
+//  Created by Gabriel Maldonado Almendra on 26/7/21.
+//
+
+import Foundation
+/*
+ * The Stocks struct will hold the JSON data output. Conforms to Codable and Identifiable protocols in order to work properly with JSON objects
+ */
+struct Stock: Codable, Identifiable {
+
+    var id: Int
+    var ticker : String
+    // TODO: https://github.com/iamgabrielma/TA-Signals/issues/4
+    var rsi: String
+    var ema100: String
+    var ema200: String
+    var signal: String
+}

--- a/TA Signals/StocksDataFetcher.swift
+++ b/TA Signals/StocksDataFetcher.swift
@@ -11,9 +11,9 @@ import Foundation
  */
 
 
-class FetchStocks {
+class StocksDataFetcher {
     // 1. When the @Published property changes, a signal will be sent so the List within the ContentView is updated
-    @Published var stocks = [Stocks]()
+    @Published var stocks = [Stock]()
     // Classes in Swift do not have memberwise initializers ( like Structs do ) so we need to declare our own:
     
     init() {
@@ -29,7 +29,7 @@ class FetchStocks {
                 // Question: I understand the "if let/else" is used to unwrap an optional, however there's no optional. The intention is the same though: If stockData contains data, decode it and dispatch it to the main thread queue. Otherwise return "no data".
                 if let stockData = data {
                     // 3. The data is decoded to an array of Stock items and assigned to the stocks property.
-                    let decodedData = try JSONDecoder().decode([Stocks].self, from: stockData)
+                    let decodedData = try JSONDecoder().decode([Stock].self, from: stockData)
                     // The task is added to the queue in the main thread of the current process, and will be executed immediately
                     DispatchQueue.main.async{
                         self.stocks = decodedData


### PR DESCRIPTION
- Renamed struct Stocks to Stock: Each object represents a single stock, so it shouldn’t be plural.
- Renamed FetchStocks to StocksDataFetcher, as represents a thing, not an action.
- Moved Stock to its own file Stock.swift

fixes #12 