### PR TITLE
[ WIP] Moved test_styling function into its own separate custom swiftUI View

### DIFF
--- a/TA Signals.xcodeproj/project.pbxproj
+++ b/TA Signals.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		680E0DA326AD3C6000D06D28 /* StocksDataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680E0DA226AD3C6000D06D28 /* StocksDataFetcher.swift */; };
 		6851BA6A26AEE84A00E52C4B /* Stock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6851BA6926AEE84A00E52C4B /* Stock.swift */; };
+		6851BA6C26AEEE6B00E52C4B /* StockListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6851BA6B26AEEE6B00E52C4B /* StockListCell.swift */; };
 		6865F1542684448B00C098B1 /* TA_SignalsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6865F1532684448B00C098B1 /* TA_SignalsApp.swift */; };
 		6865F1562684448B00C098B1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6865F1552684448B00C098B1 /* ContentView.swift */; };
 		6865F1582684448D00C098B1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6865F1572684448D00C098B1 /* Assets.xcassets */; };
@@ -37,6 +38,7 @@
 /* Begin PBXFileReference section */
 		680E0DA226AD3C6000D06D28 /* StocksDataFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StocksDataFetcher.swift; sourceTree = "<group>"; };
 		6851BA6926AEE84A00E52C4B /* Stock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stock.swift; sourceTree = "<group>"; };
+		6851BA6B26AEEE6B00E52C4B /* StockListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockListCell.swift; sourceTree = "<group>"; };
 		6865F1502684448B00C098B1 /* TA Signals.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TA Signals.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6865F1532684448B00C098B1 /* TA_SignalsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TA_SignalsApp.swift; sourceTree = "<group>"; };
 		6865F1552684448B00C098B1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 				6865F1592684448D00C098B1 /* Preview Content */,
 				680E0DA226AD3C6000D06D28 /* StocksDataFetcher.swift */,
 				6851BA6926AEE84A00E52C4B /* Stock.swift */,
+				6851BA6B26AEEE6B00E52C4B /* StockListCell.swift */,
 			);
 			path = "TA Signals";
 			sourceTree = "<group>";
@@ -267,6 +270,7 @@
 			files = (
 				6865F1562684448B00C098B1 /* ContentView.swift in Sources */,
 				6865F1542684448B00C098B1 /* TA_SignalsApp.swift in Sources */,
+				6851BA6C26AEEE6B00E52C4B /* StockListCell.swift in Sources */,
 				6851BA6A26AEE84A00E52C4B /* Stock.swift in Sources */,
 				680E0DA326AD3C6000D06D28 /* StocksDataFetcher.swift in Sources */,
 			);

--- a/TA Signals/ContentView.swift
+++ b/TA Signals/ContentView.swift
@@ -57,18 +57,20 @@ struct ContentView: View {
                     if showFetchDetails {
                         // 2. A list is created containing the todo items
                         List(fetchedObject.stocks) { stock in
-                            VStack(alignment: .leading){
-                                HStack(spacing: 25){
-                                    Text(stock.ticker)
-                                    (test_styling(item: stock.signal, type: "signal"))
-                                    VStack(){
-                                        (test_styling(item: stock.rsi, type: "rsi"))
-                                        Text("EMA100: \(stock.ema100)")
-                                        Text("EMA200: \(stock.ema200)")
-                                    }
-                                }
-                                Divider()
-                            }
+                            // Implement custom view via StockListCell.swift:
+                            StockListCell(stock: stock)
+//                            VStack(alignment: .leading){
+//                                HStack(spacing: 25){
+//                                    Text(stock.ticker)
+//                                    (test_styling(item: stock.signal, type: "signal"))
+//                                    VStack(){
+//                                        (test_styling(item: stock.rsi, type: "rsi"))
+//                                        Text("EMA100: \(stock.ema100)")
+//                                        Text("EMA200: \(stock.ema200)")
+//                                    }
+//                                }
+//                                Divider()
+//                            }
                         }// <!-- List
                         Text("This is not financial or investment advice. The Content is for informational purposes only.").font(.caption)
                     //} //! -- Section && Text attempt

--- a/TA Signals/ContentView.swift
+++ b/TA Signals/ContentView.swift
@@ -22,23 +22,6 @@ struct ContentView: View {
             return "closed"
         }
     }
-    // TODO: https://github.com/iamgabrielma/TA-Signals/issues/6
-    func test_styling(item: String, type: String) -> Text {
-        
-        var styledSignal : Text = Text(item)
-        
-        if type == "signal" {
-            styledSignal = Text(item).foregroundColor(.red)
-        }
-        else if type == "rsi" {
-            styledSignal = Text("RSI: \(item)" as String)
-        }
-        else {
-            styledSignal = Text(item)
-        }
-        
-        return styledSignal
-    }
     
     func fetchUpdate() -> Void{
         // TODO: https://github.com/iamgabrielma/TA-Signals/issues/7
@@ -54,27 +37,13 @@ struct ContentView: View {
                     Text("Market is \(openOrClosed(b: isMarketOpen))").font(.caption)
                     Text("Now: \(now, style: .date)").font(.caption)
                     Text("Last Fetch: June 25, 2021").font(.caption)
+                    
                     if showFetchDetails {
                         // 2. A list is created containing the todo items
                         List(fetchedObject.stocks) { stock in
-                            // Implement custom view via StockListCell.swift:
                             StockListCell(stock: stock)
-//                            VStack(alignment: .leading){
-//                                HStack(spacing: 25){
-//                                    Text(stock.ticker)
-//                                    (test_styling(item: stock.signal, type: "signal"))
-//                                    VStack(){
-//                                        (test_styling(item: stock.rsi, type: "rsi"))
-//                                        Text("EMA100: \(stock.ema100)")
-//                                        Text("EMA200: \(stock.ema200)")
-//                                    }
-//                                }
-//                                Divider()
-//                            }
-                        }// <!-- List
+                        }
                         Text("This is not financial or investment advice. The Content is for informational purposes only.").font(.caption)
-                    //} //! -- Section && Text attempt
-
                     }
                 }
                 .navigationTitle("TA Signals")

--- a/TA Signals/StockListCell.swift
+++ b/TA Signals/StockListCell.swift
@@ -1,0 +1,37 @@
+//
+//  StockListCell.swift
+//  TA Signals
+//
+//  Created by Gabriel Maldonado Almendra on 26/7/21.
+//
+
+import SwiftUI
+
+// Single Stock View
+struct StockListCell: View {
+    
+    let stock : Stock
+    
+    var body: some View {
+        VStack(alignment: .leading){
+            HStack(spacing: 25){
+                Text(stock.ticker)
+                //(test_styling(item: stock.signal, type: "signal"))
+                VStack(){
+                    //(test_styling(item: stock.rsi, type: "rsi"))
+                    Text("EMA100: \(stock.ema100)")
+                    Text("EMA200: \(stock.ema200)")
+                }
+            }
+            Divider()
+        }
+    }
+}
+
+struct StockListCell_Previews: PreviewProvider {
+    static var previews: some View {
+        // 1 - Error: From what I understand here, I should pass the instance of Stock() but is throwing: Missing argument for parameter 'from' in call. Is it expecting the JSOn decoder?
+        // 2- Seems I need to pass 1 stock like: StockListCell(stock: Stock(id: T##Int, ticker: T##String, rsi: T##String, ema100: T##String, ema200: T##String, signal: T##String)), is it because it needs and initializer, and I have not set default values in the struct declaration?
+        StockListCell(stock: Stock(id: 0, ticker: "none", rsi: "0", ema100: "0", ema200: "0", signal: "None"))
+    }
+}

--- a/TA Signals/StockListCell.swift
+++ b/TA Signals/StockListCell.swift
@@ -16,9 +16,9 @@ struct StockListCell: View {
         VStack(alignment: .leading){
             HStack(spacing: 25){
                 Text(stock.ticker)
-                //(test_styling(item: stock.signal, type: "signal"))
+                Text(stock.signal)
                 VStack(){
-                    //(test_styling(item: stock.rsi, type: "rsi"))
+                    Text("RSI: \(stock.rsi)")
                     Text("EMA100: \(stock.ema100)")
                     Text("EMA200: \(stock.ema200)")
                 }
@@ -30,8 +30,7 @@ struct StockListCell: View {
 
 struct StockListCell_Previews: PreviewProvider {
     static var previews: some View {
-        // 1 - Error: From what I understand here, I should pass the instance of Stock() but is throwing: Missing argument for parameter 'from' in call. Is it expecting the JSOn decoder?
-        // 2- Seems I need to pass 1 stock like: StockListCell(stock: Stock(id: T##Int, ticker: T##String, rsi: T##String, ema100: T##String, ema200: T##String, signal: T##String)), is it because it needs and initializer, and I have not set default values in the struct declaration?
-        StockListCell(stock: Stock(id: 0, ticker: "none", rsi: "0", ema100: "0", ema200: "0", signal: "None"))
+        
+        StockListCell(stock: Stock(id: 0, ticker: "NONE", rsi: "0", ema100: "0", ema200: "0", signal: "Neutral"))
     }
 }

--- a/TA Signals/StocksDataFetcher.swift
+++ b/TA Signals/StocksDataFetcher.swift
@@ -13,9 +13,10 @@ import Foundation
 
 class StocksDataFetcher {
     // 1. When the @Published property changes, a signal will be sent so the List within the ContentView is updated
+    // The variable stocks contains an array of Stock objects
     @Published var stocks = [Stock]()
-    // Classes in Swift do not have memberwise initializers ( like Structs do ) so we need to declare our own:
     
+    // Classes in Swift do not have memberwise initializers ( like Structs do ) so we need to declare our own:
     init() {
         // Original:
 //        let url = URL(string: "https://raw.githubusercontent.com/iamgabrielma/Python-for-stock-market-analysis/main/testData/2021-06-25-rsi.json")!


### PR DESCRIPTION
This PR moves the current `test_styling()` function in the `ContentView` to its separate custom SwiftUI View on a separate file. This was we can change this:

```
List(fetchedObject.stocks) { stock in
      VStack(alignment: .leading){
          HStack(spacing: 25){
              Text(stock.ticker)
              (test_styling(item: stock.signal, type: "signal"))
              VStack(){
                  (test_styling(item: stock.rsi, type: "rsi"))
                  Text("EMA100: \(stock.ema100)")
                  Text("EMA200: \(stock.ema200)")
              }
          }
          Divider()
      }
}
```

To :

```
List(fetchedObject.stocks) { stock in
	StockListCell(stock: stock)
}
```